### PR TITLE
Reduce image size by using slim-buster, Include Date&Time in log output, fix issue #6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,22 @@
-FROM python:3.8-buster
+FROM python:3.8-slim-buster
 
 LABEL maintainer="Aiden Gilmartin" \
     description="Speedtest to InfluxDB data bridge"
 
 # Install dependencies
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get -q -y install --no-install-recommends apt-utils gnupg1 apt-transport-https dirmngr
-
-# Install speedtest-cli
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
-RUN echo "deb https://ookla.bintray.com/debian buster main" | tee  /etc/apt/sources.list.d/speedtest.list
-RUN apt-get update && apt-get -q -y install speedtest
+RUN apt-get update && \
+    apt-get -q -y install --no-install-recommends apt-utils gnupg1 apt-transport-https dirmngr && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61 && \
+    echo "deb https://ookla.bintray.com/debian buster main" | tee  /etc/apt/sources.list.d/speedtest.list && \
+    apt-get update && apt-get -q -y install speedtest && \
+    apt-get -q -y autoremove && \
+    apt-get -q -y clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install Python packages
 COPY requirements.txt /
-RUN pip install -r /requirements.txt
-
-# Clean up
-RUN apt-get -q -y autoremove
-RUN apt-get -q -y clean
-RUN rm -rf /var/lib/apt/lists/*
+RUN pip3 install -r /requirements.txt
 
 # Final setup & execution
 COPY . /app

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Be aware that this script will automatically accept the license and GDPR stateme
 
 2. Install the InfluxDB client for library from Python.
 
-    `pip install influxdb`
+    `pip3 install influxdb`
 
 3. Run the script.
 
@@ -35,4 +35,34 @@ Be aware that this script will automatically accept the license and GDPR stateme
 2. Run the container.
 
     `docker run -d --name speedtest-influx aidengilmartin/speedtest-influx`
+
+## Environment Variables
+
+Use OS or Docker environmet variables to configure the program run.
+
+Example: `docker run -d --env DB_ADDRESS= influx_db --env TEST_INTERVAL=120 --name speedtest-influx aidengilmartin/speedtest-influx`
+### InfluxDB Settings
+
+| Variable          | Default Value        | Informations                                                 |
+|:------------------|:---------------------|:-------------------------------------------------------------|
+| DB_ADDRESS        | db_hostname.network  | FQDN of InfluxDB Server                                      |
+| DB_PORT           | 8086                 | Port Number of InfluxDB Server                               |
+| DB_USER           | db_username          | InfluxDB user name                                           |
+| DB_PASSWORD       | db_password          | InfluxDB password                                            |
+| DB_DATABASE       | speedtest_db         | InfluxDB database name                                       |
+| DB_RETRY_INVERVAL | 60                   | Time before retrying a failed data upload.                   |
+
+
+### Speedtest Settings
+
+| Variable           | Default Value          | Informations                                               |
+|:-------------------|:-----------------------|:-----------------------------------------------------------|
+| TEST_INTERVAL      | 1800                   | Time between tests (in seconds).                           |
+| TEST_FAIL_INTERVAL | 60                     | Time before retrying a failed Speedtest (in seconds).      |
+
+### Loglevel Settings
+
+| Variable         | Default Value          | Informations                                                                                  |
+|:-----------------|:-----------------------|:----------------------------------------------------------------------------------------------|
+| PRINT_DATA       | False                  | Print Test Data in Log (True or False)                                                        | 
 

--- a/grafana_dashboard_template.json
+++ b/grafana_dashboard_template.json
@@ -1,0 +1,396 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_SPEEDTESTS",
+      "label": "speedtests",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "6.4.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_SPEEDTESTS}",
+      "decimals": null,
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": true,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "alias": "Download",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "download",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "bandwidth"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Upload",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "upload",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "bandwidth"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Bandwidth",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "Mbits",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_SPEEDTESTS}",
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "alias": "Latency",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ping",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "latency"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "Jitter",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ping",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "jitter"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "distinct"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Ping",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 20,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Speedtests",
+  "uid": "qARRyNaWk",
+  "version": 3
+}


### PR DESCRIPTION
Hi Aiden, 

I hope I improved your speedtest app a bit. 

- By using python:3.8-slim-buster as base image and use only two RUN commands I could shrink the image from ~500MB to ~111MB.
- Sometimes packetLoss is missing in the return value of speedtest causing main.py to crash. 
'packetLoss': float(data.get('packetLoss', 0.0)) should use a default value of 0 in this case. Issue #6 
- I change the log output to include date&time `Info : 30/12/2020 15:49:52 : Speedtest successful`
- You can now use environment variabls to pass parameter to the program to avoid always build the image if you change something.
- I included your grafana dashboard sample. 

Regards,
Reiner