### PR TITLE
Pinning InfluxDB version. Avoiding bootstrap fail on v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   influxdb:
     container_name: influxdb
-    image: "influxdb:latest"
+    image: "influxdb:1.8"
     restart: unless-stopped
     env_file:
       - ./docker_env/influxdb.env


### PR DESCRIPTION
Bootstrapping process fails on current "latest" InfluxDB container version.
Pinning it to the "latest" 1.8 version.